### PR TITLE
feat(order-service): 주문 생성 이벤트 발행 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
 plugins {
-    // 루트에서는 Spring Boot 플러그인을 apply하지 않는다
-    // 각 모듈에서 직접 적용한다.
     id("io.spring.dependency-management") version "1.1.4"
     java
 }
@@ -22,6 +20,12 @@ subprojects {
 
     apply(plugin = "java")
     apply(plugin = "io.spring.dependency-management")
+
+    dependencyManagement {
+        imports {
+            mavenBom("org.springframework.boot:spring-boot-dependencies:3.2.3")
+        }
+    }
 
     dependencies {
         testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,14 +8,17 @@ java {
 }
 
 dependencies {
-    // Lombok (공통 DTO에 사용)
+    // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    // Jackson (이벤트 직렬화/역직렬화)
+    // Jackson
     implementation("com.fasterxml.jackson.core:jackson-databind")
 
-    // Kafka event 기반을 위해 필요 (하지만 Boot는 각 서비스에서 적용)
+    // Spring Core (Configuration / Bean 사용)
+    implementation("org.springframework:spring-context")
+
+    // Kafka
     implementation("org.springframework.kafka:spring-kafka")
 }
 

--- a/common/src/main/java/com/eventflow/common/config/KafkaConfig.java
+++ b/common/src/main/java/com/eventflow/common/config/KafkaConfig.java
@@ -1,0 +1,88 @@
+package com.eventflow.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    // ------------------------------
+    // ObjectMapper (공통)
+    // ------------------------------
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    // ------------------------------
+    // Producer Factory
+    // ------------------------------
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(ObjectMapper objectMapper) {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        JsonSerializer<Object> jsonSerializer = new JsonSerializer<>(objectMapper);
+        jsonSerializer.setAddTypeInfo(false);
+
+        return new DefaultKafkaProducerFactory<>(
+                config,
+                new StringSerializer(),
+                jsonSerializer
+        );
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(
+            ProducerFactory<String, Object> producerFactory
+    ) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    // ------------------------------
+    // Consumer Factory
+    // ------------------------------
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory(ObjectMapper objectMapper) {
+
+        JsonDeserializer<Object> jsonDeserializer = new JsonDeserializer<>(objectMapper);
+        jsonDeserializer.addTrustedPackages("*");
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(
+                config,
+                new StringDeserializer(),
+                jsonDeserializer
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object>
+    kafkaListenerContainerFactory(ConsumerFactory<String, Object> consumerFactory) {
+
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}

--- a/common/src/main/java/com/eventflow/common/event/OrderCreatedEvent.java
+++ b/common/src/main/java/com/eventflow/common/event/OrderCreatedEvent.java
@@ -35,4 +35,24 @@ public class OrderCreatedEvent {
         private Integer quantity;
         private Integer price;
     }
+
+    public static OrderCreatedEvent of(
+            EventHeader header ,
+            String orderId,
+            String userId,
+            Integer totalPrice,
+            List<OrderItem> items
+    ) {
+        Payload payload = Payload.builder()
+                .orderId(orderId)
+                .userId(userId)
+                .totalPrice(totalPrice)
+                .items(items)
+                .build();
+
+        return OrderCreatedEvent.builder()
+                .header(header)
+                .payload(payload)
+                .build();
+    }
 }

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -12,6 +12,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    // Kafka Producer 사용을 위함
+    implementation("org.springframework.kafka:spring-kafka")
+
+    // common 모듈 (DTO + KafkaConfig)
+    implementation(project(":common"))
+
     runtimeOnly("com.h2database:h2")
 
     compileOnly("org.projectlombok:lombok")

--- a/order-service/src/main/java/com/eventflow/order/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/eventflow/order/OrderServiceApplication.java
@@ -1,0 +1,11 @@
+package com.eventflow.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OrderServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OrderServiceApplication.class, args);
+    }
+}

--- a/order-service/src/main/java/com/eventflow/order/application/OrderApplicationService.java
+++ b/order-service/src/main/java/com/eventflow/order/application/OrderApplicationService.java
@@ -1,0 +1,36 @@
+package com.eventflow.order.application;
+
+import com.eventflow.common.event.EventHeader;
+import com.eventflow.common.event.OrderCreatedEvent;
+import com.eventflow.order.infrastructure.kafka.OrderEventProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OrderApplicationService {
+    private final OrderEventProducer eventProducer;
+    public void createOrder(String orderId, String userId, Integer totalPrice) {
+        EventHeader header = EventHeader.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType("order.created")
+                .version("1.0")
+                .timestamp(System.currentTimeMillis())
+                .source("order-service")
+                .build();
+
+        List<OrderCreatedEvent.OrderItem> items = List.of();
+
+        OrderCreatedEvent event = OrderCreatedEvent.of(
+                header,
+                orderId,
+                userId,
+                totalPrice,
+                items
+        );
+        eventProducer.publish(event);
+    }
+}

--- a/order-service/src/main/java/com/eventflow/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/eventflow/order/controller/OrderController.java
@@ -1,0 +1,25 @@
+package com.eventflow.order.controller;
+
+import com.eventflow.order.application.OrderApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderApplicationService orderService;
+
+    @PostMapping("/create")
+    public String createOrder(
+            @RequestParam String orderId,
+            @RequestParam String userId,
+            @RequestParam Integer totalPrice
+    ){
+        orderService.createOrder(orderId, userId, totalPrice);
+        return "order.create publish 성공!";
+    }
+}

--- a/order-service/src/main/java/com/eventflow/order/infrastructure/kafka/OrderEventProducer.java
+++ b/order-service/src/main/java/com/eventflow/order/infrastructure/kafka/OrderEventProducer.java
@@ -1,0 +1,20 @@
+package com.eventflow.order.infrastructure.kafka;
+
+import com.eventflow.common.event.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderEventProducer {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private static final String TOPIC = "order.created";
+
+    public void publish(OrderCreatedEvent event) {
+        log.info("[ORDER-PRODUCER] Publishing event -> {}", event);
+        kafkaTemplate.send(TOPIC,event);
+    }
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8081
+
 spring:
   application:
     name: order-service

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: order-service
+
+  kafka:
+    bootstrap-servers: localhost:9092
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+    consumer:
+      group-id: order-service-group


### PR DESCRIPTION
#4 
## 🔥 개요

`order-service`에 **주문 생성 기능과 Kafka 기반 `OrderCreatedEvent` 발행 구조**를 모두 구현했습니다.
EDA(Event-Driven Architecture) 기반 커머스 파이프라인의 첫 단계인
**“주문 생성 → 이벤트 발행”** 흐름을 구축한 PR입니다.

이번 PR을 통해 아래 기능들이 모두 준비되었습니다:

* order-service의 주문 생성 서비스 로직
* EventHeader + Payload 구조의 공통 이벤트 DTO 활용
* Kafka Producer 연동 및 이벤트 발행
* 테스트용 OrderController 추가
* order-service 실행을 위한 `application.yml` 설정

---

## 🛠 구현한 주요 기능

### 1. **Kafka Producer 연동 (KafkaTemplate 활용)**

* common 모듈의 `KafkaConfig`를 import하여 Producer 환경 구성
* order-service에서는 별도의 Kafka 설정 없이 공통 설정 활용

---

### 2. **OrderCreatedEvent 발행 기능 구현**

* EventHeader + Payload 구조 기반 이벤트 생성 로직 완성
* `OrderCreatedEvent.of()` 정적 팩토리 메서드로 이벤트 생성 과정 캡슐화
* `userId` → String, `totalPrice` → Integer 타입으로 통일
* 서비스 레이어에서 단일 메서드 호출만으로 이벤트 생성 가능

---

### 3. **OrderApplicationService 추가**

* 주문 생성 요청 처리
* EventHeader 생성 로직 구현
* OrderCreatedEvent 생성 및 Kafka Producer 발행
* 결제/재고/배송 서비스로 이어지는 이벤트 기반 흐름의 시작점 역할

---

### 4. **OrderController 구성**

* 테스트용 주문 생성 API 추가
* `POST /orders/create` 제공
* `orderId`, `userId`, `totalPrice`를 Query Parameter 로 입력
* 이벤트 발행 후 성공 메세지 반환

---

### 5. **application.yml 생성**

order-service 실행 및 Kafka 연동을 위한 기본 설정 추가:

* Spring Application Name
* Kafka bootstrap-servers
* Producer/Consumer serializer 설정
* consumer group-id (`order-service-group`)